### PR TITLE
fiodriver: fix sending of frame 62 for CMU fail state action

### DIFF
--- a/fio/src/fiodriver/fioframe.c
+++ b/fio/src/fiodriver/fioframe.c
@@ -306,7 +306,7 @@ fioman_ready_generic_tx_frame
 		p_tx->when = FIOMSG_CURRENT_TIME;		/* Set when to send frame */
 		p_tx->fioman_context = (void *)p_sys_fiod;
 		p_tx->fiod = p_sys_fiod->fiod;
-		copy_from_user(FIOMSG_PAYLOAD(p_tx), payload, count);
+		copy_from_user(FIOMSG_PAYLOAD(p_tx)->frame_info, payload, count);
 	}
 	else
 	{

--- a/fio/src/fiodriver/fioframe.c
+++ b/fio/src/fiodriver/fioframe.c
@@ -881,13 +881,19 @@ fioman_tx_frame_62
 {
 	FIOMAN_SYS_FIOD		*p_sys_fiod;	/* For access to System info */
 	unsigned long	flags;
+  unsigned char action = 0;
 
 	/* Get access to system info */
 	p_sys_fiod = (FIOMAN_SYS_FIOD *)p_tx_frame->fioman_context;
 
 	spin_lock_irqsave(&p_sys_fiod->lock, flags);
 	/* Copy data from FIOD System setting */
-	FIOMSG_PAYLOAD(p_tx_frame)->frame_info[0] = p_sys_fiod->cmu_fsa;
+  if (p_sys_fiod->cmu_fsa == FIO_CMU_FSA_LATCHING) {
+    action = 1;
+  } else if (p_sys_fiod->cmu_fsa == FIO_CMU_FSA_NON_LATCHING) {
+    action = 2;
+  }
+	FIOMSG_PAYLOAD(p_tx_frame)->frame_info[0] = action;
 	spin_unlock_irqrestore(&p_sys_fiod->lock, flags);
 }
 

--- a/fio/src/fiodriver/fioman.c
+++ b/fio/src/fiodriver/fioman.c
@@ -726,13 +726,9 @@ fioman_add_def_fiod_frames
 			if (rx_frame)
 				list_add_tail( &((FIOMSG_RX_FRAME *)(rx_frame))->elem, rx_frames );
 
-#if 0
-			/* Indicate other valid frames not sent by default (FIO332,FIOTS1,FIOINSIU,FIOOUTSIU) */
-			p_fiod->frame_frequency_table[60] = FIO_HZ_0;
-			p_fiod->frame_frequency_table[61] = FIO_HZ_0;
+			/* Indicate other valid frames not sent by default (FIOCMU) */
 			p_fiod->frame_frequency_table[62] = FIO_HZ_0;
-			p_fiod->frame_frequency_table[65] = FIO_HZ_0;
-#endif
+
 			break;
 		}
 


### PR DESCRIPTION
Allow CMU frame 62 to be scheduled with fio_fiod_frame_schedule_set().
Fix frame 62 payload bits to correctly reflect fio_cmu_fsa enumeration.
Fix payload handling for fio_fiod_frame_write().