### PR TITLE
fpui: restore virtual screen and settings on panel hardware reset

### DIFF
--- a/fpu/FrontPanelSystem/FrontPanelManager/ViewportManager.c
+++ b/fpu/FrontPanelSystem/FrontPanelManager/ViewportManager.c
@@ -557,6 +557,10 @@ void viewport_listener( char *filepath )
 								break;
 							case PWR_UP:	// The UI powered up or reset
 								DBG( "%s: POWER UP sequence\n", __func__ );
+                display_present = true;
+                check_screen_size( fd );
+                set_focus(has_focus);
+                ping = false;
 								virtual_terminal_return( has_focus, buf );
 								break;
 							case STATUS: //Status at cursor position


### PR DESCRIPTION
Front Panel Manager detects panel hardware removal if longer than 5 seconds, but not a short reset as from panel reset button or CPURESET operation. Act on the sequence "ESC [PU" sent by the panel hardware following reset.
Resolves  https://jira.q-free-america.com/browse/MT-1304