### PR TITLE
fiodriver: change logging level of duplicate rx frame message to debug only

### DIFF
--- a/fio/src/fiodriver/fiomsg.c
+++ b/fio/src/fiodriver/fiomsg.c
@@ -669,8 +669,7 @@ fiomsg_rx_add_frame
 			if ( FIOMSG_PAYLOAD( p_rx_elem )->frame_no ==
 				 FIOMSG_PAYLOAD( p_frame )->frame_no )
 			{
-				printk( KERN_ALERT
-						"Trying to add existing RX frame(%d), killing!\n",
+				pr_debug("Trying to add existing RX frame(%d), killing!\n",
 						FIOMSG_PAYLOAD( p_frame )->frame_no );
 				kfree( p_frame );
 				return;


### PR DESCRIPTION
RX frame instance cannot be removed on reception in case of call to fio_fiod_frame_read(); rx frame added automatically on call to fio_fiod_frame_write(). Duplicate rx frame instance is safely discarded, so log as debug level message.
Resolves https://jira.q-free-america.com/browse/MT-1302
