### PR TITLE
fiodriver: handle frame 54 block number

### DIFF
--- a/fio/src/fiodriver/fioframe.c
+++ b/fio/src/fiodriver/fioframe.c
@@ -666,11 +666,13 @@ fioman_tx_frame_54
 	FIOMSG_TX_FRAME		*p_tx_frame		/* Frame about to be sent */
 )
 {
+  FIOMAN_SYS_FIOD		*p_sys_fiod;	/* For access to System info */
 /* TEG DEL */
 pr_debug( "UPDATING Frame 54\n" );
 /* TEG DEL */
-        FIOMSG_PAYLOAD(p_tx_frame)->frame_info[0]++;
-        
+  /* Get access to system info */
+	p_sys_fiod = (FIOMAN_SYS_FIOD *)p_tx_frame->fioman_context;
+  FIOMSG_PAYLOAD(p_tx_frame)->frame_info[0] = p_sys_fiod->input_transition_block;
 }
 
 /*****************************************************************************/
@@ -2709,6 +2711,7 @@ fioman_rx_frame_182
                         }
                 }
         }
+  p_sys_fiod->input_transition_block++;
 	spin_unlock_irqrestore(&p_sys_fiod->lock, flags);
 
 /* TEG DEL */

--- a/fio/src/fiodriver/fioman.c
+++ b/fio/src/fiodriver/fioman.c
@@ -1251,7 +1251,8 @@ fioman_reg_fiod
 		p_sys_fiod->cmu_config_change_count = 0;
 		p_sys_fiod->watchdog_output = -1;
 		p_sys_fiod->watchdog_state = false;
-                p_sys_fiod->watchdog_rate = FIO_HZ_0;
+    p_sys_fiod->watchdog_rate = FIO_HZ_0;
+    p_sys_fiod->input_transition_block = 0;
 		for (i=0; i<128; i++) {
 			/* Indicate invalid frame by default */
 			p_sys_fiod->frame_frequency_table[i] = -1;

--- a/fio/src/fiodriver/fioman.h
+++ b/fio/src/fiodriver/fioman.h
@@ -96,7 +96,8 @@ struct fioman_sys_fiod
 	u8	input_filters_leading[ FIO_INPUT_POINTS_BYTES * 8 ];
 	u8	input_filters_trailing[ FIO_INPUT_POINTS_BYTES * 8 ];
 	u8	input_transition_map[ FIO_INPUT_POINTS_BYTES ];		/* Inputs enabled for transition reporting */
-
+  u8  input_transition_block;
+  
 	u8	channels_reserved[ FIO_CHANNEL_BYTES ];
 									/* Channel mapping of Outputs for FIOD */
 	u8	channel_map_red[ FIO_CHANNELS ];


### PR DESCRIPTION
Only increment the transition buffer request block number after successfully receiving a block.
Fixes https://jira.q-free-america.com/browse/MT-1367 