### PR TITLE
MT-1433 Frame 51 fixes for transition reporting

### DIFF
--- a/fio/src/fiodriver/fioframe.c
+++ b/fio/src/fiodriver/fioframe.c
@@ -50,6 +50,7 @@ extern FIOMSG_TIME fiomsg_tx_frame_when(FIO_HZ freq);
 extern int local_time_offset;
 extern FIOMSG_PORT	fio_port_table[ FIO_PORTS_MAX ];
 extern FIOMSG_TX_FRAME *fioman_get_tx_frame(FIOMAN_SYS_FIOD *, int);
+extern FIOMSG_TX_FRAME *fioman_remove_frame(FIOMAN_SYS_FIOD *, int);
 
 /*  Global section.
 -----------------------------------------------------------------------------*/
@@ -2570,9 +2571,7 @@ fioman_rx_frame_179
     spin_lock_irqsave(&p_sys_fiod->lock, flags);
     p_sys_fiod->inputs_configured = true;
     /* Remove frame 51 from schedule */
-    if ((p_tx_frame = fioman_get_tx_frame(p_sys_fiod, FIOMAN_FRAME_NO_51)) != NULL) {
-      p_tx_frame->cur_freq = FIO_HZ_0;
-    }
+    fioman_remove_frame(p_sys_fiod, FIOMAN_FRAME_NO_51);
     spin_unlock_irqrestore(&p_sys_fiod->lock, flags);
   }
     

--- a/fio/src/fiodriver/fioman.c
+++ b/fio/src/fiodriver/fioman.c
@@ -572,6 +572,43 @@ fioman_add_frame
 
 /*****************************************************************************/
 /*
+This function is used to remove a specific request frame and response, if any
+*/
+/*****************************************************************************/
+int
+fioman_remove_frame
+(
+	FIOMAN_SYS_FIOD	*p_sys_fiod,		/* FIOD of destined frame */
+	int frame_no
+)
+{
+  struct list_head	*p_elem;	/* Ptr to queue element being examined */
+	struct list_head	*p_next;	/* Temp Ptr to next for loop */
+	FIOMSG_TX_FRAME		*p_tx_elem;	/* Ptr to tx frame being examined */
+	FIOMSG_PORT		*p_port;	/* Port of Request Queue */
+
+  /* Search for frame in tx queue */
+  /* Get port to work on */
+  p_port = FIOMSG_P_PORT(p_sys_fiod->fiod.port);
+  /* For each element in the queue */
+  list_for_each_safe(p_elem, p_next, &p_port->tx_queue) {
+    /* Get the request frame for this queue element */
+    p_tx_elem = list_entry(p_elem, FIOMSG_TX_FRAME, elem);
+    /* See if current element matches fiod */
+    if (p_tx_elem->fiod.fiod == p_sys_fiod->fiod.fiod) {
+      /* Does the frame number match one requested? */
+      if (FIOMSG_PAYLOAD(p_tx_elem)->frame_no == frame_no) {
+        list_del_init(p_elem);
+        kfree(p_tx_elem);
+      }
+    }
+  }
+  return(-EINVAL);
+
+}
+
+/*****************************************************************************/
+/*
 This function adds the default frames for a port (given the indicated FIOD)
 to the request frame list for this port, for the first time the port is
 accessed.
@@ -1814,15 +1851,9 @@ fioman_outputs_set
 		p_sys_fiod->outputs_minus[ ii ] |= minus[ ii ];
 	}
 	spin_unlock_irqrestore(&p_sys_fiod->lock, flags);
-pr_debug("fioman_outputs_set: %x %x %x %x %x %x %x %x\n",
-	plus[0]|minus[0],
-	plus[1]|minus[1],
-	plus[2]|minus[2],
-	plus[3]|minus[3],
-	plus[4]|minus[4],
-	plus[5]|minus[5],
-	plus[6]|minus[6],
-	plus[7]|minus[7]);
+/*pr_debug("fioman_outputs_set:+%x %x %x %x %x %x %x %x -%x %x %x %x %x %x %x %x\n",
+	plus[0], plus[1], plus[2], plus[3], plus[4], plus[5], plus[6], plus[7],
+  minus[0], minus[1], minus[2], minus[3], minus[4], minus[5], minus[6], minus[7]);*/
 	/* return success */
 	return ( 0 );
 }
@@ -2794,8 +2825,8 @@ fioman_inputs_get
 	}
 	spin_unlock_irqrestore(&p_sys_fiod->lock, flags);
 
-        /*pr_debug( KERN_ALERT "fiod_inputs_get: fiod(%d), %x %x %x %x %x %x %x %x\n",
-                p_sys_fiod->fiod.fiod,
+  /*pr_debug( KERN_ALERT "fiod_inputs_get: fiod(%d), %x %x %x %x %x %x %x %x\n",
+    p_sys_fiod->fiod.fiod,
 		inputs[0], inputs[1], inputs[2], inputs[3],
 		inputs[4], inputs[5], inputs[6], inputs[7]);*/
 

--- a/fio/src/fiodriver/fioman.c
+++ b/fio/src/fiodriver/fioman.c
@@ -3639,13 +3639,14 @@ int fioman_inputs_trans_set
 	FIO_IOC_INPUTS_TRANS_SET	*p_arg
 )
 {
-	FIOMAN_PRIV_DATA	*p_priv = filp->private_data;	/* Access Apps data */
-	FIOMAN_APP_FIOD		*p_app_fiod;	/* Ptr to app fiod structure */
-	FIOMAN_SYS_FIOD		*p_sys_fiod;	/* Ptr to FIOMAN fiod structure */
-	unsigned char		input_trans_map[FIO_INPUT_POINTS_BYTES];
-	int i, count;
-	unsigned long flags;
-	bool update_fiod = false;
+  FIOMAN_PRIV_DATA *p_priv = filp->private_data; /* Access Apps data */
+  FIOMAN_APP_FIOD *p_app_fiod; /* Ptr to app fiod structure */
+  FIOMAN_SYS_FIOD *p_sys_fiod; /* Ptr to FIOMAN fiod structure */
+  FIOMAN_APP_FIOD *p_cmp_fiod; /* Ptr to compare app fiod */
+  struct list_head *p_app_elem; /* Ptr to app element being examined */
+  unsigned char input_trans_map[FIO_INPUT_POINTS_BYTES];
+  int i, count;
+  unsigned long flags;
 
 	/* Find this APP registration */
 	p_app_fiod = fioman_find_dev( p_priv, p_arg->dev_handle );
@@ -3654,45 +3655,43 @@ int fioman_inputs_trans_set
 		/* No, return error */
 		return -EINVAL;
 	
-        count = p_arg->count;
+  count = p_arg->count;
 	if (count <= 0) {
 		return ( -EFAULT );
 	}
 
 	if (count > FIO_INPUT_POINTS_BYTES)
-                count = FIO_INPUT_POINTS_BYTES;
+    count = FIO_INPUT_POINTS_BYTES;
 
 	p_sys_fiod = p_app_fiod->p_sys_fiod;
 	if (copy_from_user(input_trans_map, p_arg->data, count)) {
 		return -EFAULT;
 	}
 
+  /* Save app-based values */
+  memcpy(p_app_fiod->input_transition_map, input_trans_map, count);
+  
 	spin_lock_irqsave(&p_sys_fiod->lock, flags);
-	for (i=0; i<(FIO_INPUT_POINTS_BYTES*8); i++) {
-		/* Save app-based values */
-		if (FIO_BIT_TEST(input_trans_map,i)) {
-			FIO_BIT_SET(p_app_fiod->input_transition_map, i);
-			if (!FIO_BIT_TEST(p_sys_fiod->input_transition_map,i)) {
-				FIO_BIT_SET(p_sys_fiod->input_transition_map, i);
-				update_fiod = true;
-			}
-		} else {
-			FIO_BIT_CLEAR(p_app_fiod->input_transition_map, i);
-			if (FIO_BIT_TEST(p_sys_fiod->input_transition_map, i)) {
-				/* TBD: Check all apps before turning off */
-			}
-		}
-	}
+	for (i=0; i<FIO_INPUT_POINTS_BYTES; i++) {
+    /* Check all apps settings before turning off */
+    list_for_each( p_app_elem, &p_sys_fiod->app_fiod_list ) {
+      /* Get a ptr to this list entry */
+      p_cmp_fiod = list_entry( p_app_elem, FIOMAN_APP_FIOD, sys_elem );
+      input_trans_map[i] |= p_cmp_fiod->input_transition_map[i];
+    }
+  }
+  memcpy(p_sys_fiod->input_transition_map, input_trans_map, count);
 	spin_unlock_irqrestore(&p_sys_fiod->lock, flags);
+  /*pr_debug("fioman_inputs_trans_set: %02X %02X %02X %02X %02X %02X %02X %02X\n",
+    input_trans_map[0], input_trans_map[1], input_trans_map[2], input_trans_map[3],
+    input_trans_map[4], input_trans_map[5], input_trans_map[6], input_trans_map[7]);*/
 
   /* If any sys_fiod input config values have changed, we must schedule frame #51 */
-  if (update_fiod) {
-    p_sys_fiod->inputs_configured = false;
-    /* Ready frame 51 for this device */
-    if (!fioman_frame_is_scheduled(p_sys_fiod, FIOMAN_FRAME_NO_51)) {
-      p_sys_fiod->frame_frequency_table[FIOMAN_FRAME_NO_51] = FIO_HZ_10;
-      return fioman_add_frame(FIOMAN_FRAME_NO_51, p_sys_fiod);
-    }
+  p_sys_fiod->inputs_configured = false;
+  /* Ready frame 51 for this device */
+  if (!fioman_frame_is_scheduled(p_sys_fiod, FIOMAN_FRAME_NO_51)) {
+    p_sys_fiod->frame_frequency_table[FIOMAN_FRAME_NO_51] = FIO_HZ_10;
+    return fioman_add_frame(FIOMAN_FRAME_NO_51, p_sys_fiod);
   }
 	
 	return 0;
@@ -5027,7 +5026,7 @@ fioman_ioctl
 		case FIOMAN_IOC_VERSION_GET:
 		{
 			FIO_IOC_VERSION_GET *p_arg = (FIO_IOC_VERSION_GET *)arg;
-			char ver[80] = "Intelight, 1.31, 2.17";
+			char ver[80] = "Intelight, 1.32, 2.17";
 			
 			if (copy_to_user(p_arg, ver, strlen(ver) )) {
 				/* Could not copy for some reason */

--- a/fio/src/fiodriver/fioman.c
+++ b/fio/src/fiodriver/fioman.c
@@ -600,6 +600,7 @@ fioman_remove_frame
       if (FIOMSG_PAYLOAD(p_tx_elem)->frame_no == frame_no) {
         list_del_init(p_elem);
         kfree(p_tx_elem);
+        return 0;
       }
     }
   }


### PR DESCRIPTION
A subsequent call to fio_fiod_inputs_filter_set() or fio_fiod_inputs_trans_set() did not result in frame 51 being sent to the fio module as previously added frame 51 was not removed from the port tx_queue.
A subsequent call to fio_fiod_inputs_trans_set() which disabled any transition reporting did not result in frame 51 being sent to the fio module.

Resolves https://jira.q-free-america.com/browse/MT-1433