### PR TITLE
automatically modprobe fiodriver in fio_register

### DIFF
--- a/fio/src/fioapi/fio.c
+++ b/fio/src/fioapi/fio.c
@@ -81,6 +81,7 @@ fio_register
 (
 )
 {
+	system("/sbin/modprobe fiodriver");
 	return ( ( FIO_APP_HANDLE )open( FIO_DEV, O_RDWR ) );
 }
 


### PR DESCRIPTION
I added this change so that we can remove all fio init from the snap `-daemon` start scripts.  Now the fiodriver.ko kernel module is automatically loaded the first time a client calls fio_register