### PR TITLE
fiodriver: Fix conflict check for per port device compatibility

### DIFF
--- a/fio/src/fioapi/fioapi.h
+++ b/fio/src/fioapi/fioapi.h
@@ -130,7 +130,16 @@ enum fio_device_type
 typedef	enum fio_device_type	FIO_DEVICE_TYPE;
 
 #define IS_TFBIU(x)		((x>=FIOTF1)&&(x<=FIOTF8))
+#define IS_DRBIU(x)   ((x>=FIODR1)&&(x<=FIODR8))
+#define IS_MMU(x)     (x==FIOMMU)
+#define IS_NEMA(x)    ((x>=FIOMMU)&&(x<=FIOTF8))
 #define IS_OUTSIU(x)	((x>=FIOOUT6SIU1)&&(x<=FIOOUT14SIU2))
+#define IS_INSIU(x)   ((x>=FIOINSIU1)&&(x<=FIOINSIU5))
+#define IS_CMU(x)     (x==FIOCMU)
+#define IS_ITS(x)     ((x>=FIO_CMU)&&(x<=FIOOUT14SIU2))
+#define IS_FIO332(x)  (x==FIO332)
+#define IS_FIOTS1(x)  (x==FIOTS1)
+#define IS_FIOTS2(x)  (x==FIOTS2)
 
 /* HZ Definitions for Apps */
 enum fio_hz

--- a/fio/src/fiodriver/fiodrvr.c
+++ b/fio/src/fiodriver/fiodrvr.c
@@ -187,5 +187,5 @@ module_exit(fio_exit);
 
 MODULE_AUTHOR("J. Michael Gallagher, Intelight Inc. <support@intelight-its.com>");
 MODULE_DESCRIPTION( "FIO API Module for ATC" );
-MODULE_VERSION( "03.07" );
+MODULE_VERSION( "03.08" );
 MODULE_LICENSE("GPL");

--- a/fio/src/fiodriver/fioman.c
+++ b/fio/src/fiodriver/fioman.c
@@ -5381,7 +5381,7 @@ fioman_ioctl
                 case FIOMAN_IOC_VERSION_GET:
                 {
                         FIO_IOC_VERSION_GET *p_arg = (FIO_IOC_VERSION_GET *)arg;
-                        char ver[80] = "Intelight, 3.07, 2.17";
+                        char ver[80] = "Intelight, 3.08, 2.17";
 
                         if (copy_to_user(p_arg, ver, strlen(ver) )) {
                                 /* Could not copy for some reason */

--- a/fio/src/fiodriver/fioman.c
+++ b/fio/src/fiodriver/fioman.c
@@ -1235,19 +1235,9 @@ fioman_add_def_fiod_frames
 
 /*****************************************************************************/
 
-bool fiod_conflict_check( FIO_DEVICE_TYPE a, FIO_DEVICE_TYPE b)
+bool fiod_conflict_check(FIO_DEVICE_TYPE a, FIO_DEVICE_TYPE b)
 {
-	if ((a > FIO332) && (a < FIOCMU)) {
-		if ((b < FIOTS1) || (b > FIOTF8))
-			return true;
-	} else if (a > FIOTF8) {
-		if (b < FIOCMU)
-			return true;
-	} else if (b != FIO332) {
-		return true;
-	}
-	
-	return false;
+  return (IS_NEMA(a) != IS_NEMA(b));
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
No longer restricts valid device combinations.