### PR TITLE
MT-1809 Fix FIO comms issue with some module configurations

### DIFF
--- a/fio/src/fiodriver/fiodrvr.c
+++ b/fio/src/fiodriver/fiodrvr.c
@@ -280,6 +280,6 @@ $Log$
 /*****************************************************************************/
 MODULE_AUTHOR( "Thomas E. Gauger tgauger@vanteon.com" );
 MODULE_DESCRIPTION( "FIO API Module for ATC" );
-MODULE_VERSION( "1.32" );
+MODULE_VERSION( "1.33" );
 MODULE_LICENSE("GPL");
 

--- a/fio/src/fiodriver/fioman.c
+++ b/fio/src/fiodriver/fioman.c
@@ -3608,13 +3608,14 @@ int fioman_inputs_trans_set
 	FIO_IOC_INPUTS_TRANS_SET	*p_arg
 )
 {
-	FIOMAN_PRIV_DATA	*p_priv = filp->private_data;	/* Access Apps data */
-	FIOMAN_APP_FIOD		*p_app_fiod;	/* Ptr to app fiod structure */
-	FIOMAN_SYS_FIOD		*p_sys_fiod;	/* Ptr to FIOMAN fiod structure */
-	unsigned char		input_trans_map[FIO_INPUT_POINTS_BYTES];
-	int i, count;
-	unsigned long flags;
-	bool update_fiod = false;
+  FIOMAN_PRIV_DATA *p_priv = filp->private_data; /* Access Apps data */
+  FIOMAN_APP_FIOD *p_app_fiod; /* Ptr to app fiod structure */
+  FIOMAN_SYS_FIOD *p_sys_fiod; /* Ptr to FIOMAN fiod structure */
+  FIOMAN_APP_FIOD *p_cmp_fiod; /* Ptr to compare app fiod */
+  struct list_head *p_app_elem; /* Ptr to app element being examined */
+  unsigned char input_trans_map[FIO_INPUT_POINTS_BYTES];
+  int i, count;
+  unsigned long flags;
 
 	/* Find this APP registration */
 	p_app_fiod = fioman_find_dev( p_priv, p_arg->dev_handle );
@@ -3623,45 +3624,43 @@ int fioman_inputs_trans_set
 		/* No, return error */
 		return -EINVAL;
 	
-        count = p_arg->count;
+  count = p_arg->count;
 	if (count <= 0) {
 		return ( -EFAULT );
 	}
 
 	if (count > FIO_INPUT_POINTS_BYTES)
-                count = FIO_INPUT_POINTS_BYTES;
+    count = FIO_INPUT_POINTS_BYTES;
 
 	p_sys_fiod = p_app_fiod->p_sys_fiod;
 	if (copy_from_user(input_trans_map, p_arg->data, count)) {
 		return -EFAULT;
 	}
 
+  /* Save app-based values */
+  memcpy(p_app_fiod->input_transition_map, input_trans_map, count);
+  
 	spin_lock_irqsave(&p_sys_fiod->lock, flags);
-	for (i=0; i<(FIO_INPUT_POINTS_BYTES*8); i++) {
-		/* Save app-based values */
-		if (FIO_BIT_TEST(input_trans_map,i)) {
-			FIO_BIT_SET(p_app_fiod->input_transition_map, i);
-			if (!FIO_BIT_TEST(p_sys_fiod->input_transition_map,i)) {
-				FIO_BIT_SET(p_sys_fiod->input_transition_map, i);
-				update_fiod = true;
-			}
-		} else {
-			FIO_BIT_CLEAR(p_app_fiod->input_transition_map, i);
-			if (FIO_BIT_TEST(p_sys_fiod->input_transition_map, i)) {
-				/* TBD: Check all apps before turning off */
-			}
-		}
-	}
+	for (i=0; i<FIO_INPUT_POINTS_BYTES; i++) {
+    /* Check all apps settings before turning off */
+    list_for_each( p_app_elem, &p_sys_fiod->app_fiod_list ) {
+      /* Get a ptr to this list entry */
+      p_cmp_fiod = list_entry( p_app_elem, FIOMAN_APP_FIOD, sys_elem );
+      input_trans_map[i] |= p_cmp_fiod->input_transition_map[i];
+    }
+  }
+  memcpy(p_sys_fiod->input_transition_map, input_trans_map, count);
 	spin_unlock_irqrestore(&p_sys_fiod->lock, flags);
+  /*pr_debug("fioman_inputs_trans_set: %02X %02X %02X %02X %02X %02X %02X %02X\n",
+    input_trans_map[0], input_trans_map[1], input_trans_map[2], input_trans_map[3],
+    input_trans_map[4], input_trans_map[5], input_trans_map[6], input_trans_map[7]);*/
 
   /* If any sys_fiod input config values have changed, we must schedule frame #51 */
-  if (update_fiod) {
-    p_sys_fiod->inputs_configured = false;
-    /* Ready frame 51 for this device */
-    if (!fioman_frame_is_scheduled(p_sys_fiod, FIOMAN_FRAME_NO_51)) {
-      p_sys_fiod->frame_frequency_table[FIOMAN_FRAME_NO_51] = FIO_HZ_10;
-      return fioman_add_frame(FIOMAN_FRAME_NO_51, p_sys_fiod);
-    }
+  p_sys_fiod->inputs_configured = false;
+  /* Ready frame 51 for this device */
+  if (!fioman_frame_is_scheduled(p_sys_fiod, FIOMAN_FRAME_NO_51)) {
+    p_sys_fiod->frame_frequency_table[FIOMAN_FRAME_NO_51] = FIO_HZ_10;
+    return fioman_add_frame(FIOMAN_FRAME_NO_51, p_sys_fiod);
   }
 	
 	return 0;
@@ -4996,7 +4995,7 @@ fioman_ioctl
 		case FIOMAN_IOC_VERSION_GET:
 		{
 			FIO_IOC_VERSION_GET *p_arg = (FIO_IOC_VERSION_GET *)arg;
-			char ver[80] = "Intelight, 1.31, 2.17";
+			char ver[80] = "Intelight, 1.32, 2.17";
 			
 			if (copy_to_user(p_arg, ver, strlen(ver) )) {
 				/* Could not copy for some reason */

--- a/fio/src/fiodriver/fioman.c
+++ b/fio/src/fiodriver/fioman.c
@@ -4995,7 +4995,7 @@ fioman_ioctl
 		case FIOMAN_IOC_VERSION_GET:
 		{
 			FIO_IOC_VERSION_GET *p_arg = (FIO_IOC_VERSION_GET *)arg;
-			char ver[80] = "Intelight, 1.32, 2.17";
+			char ver[80] = "Intelight, 1.33, 2.17";
 			
 			if (copy_to_user(p_arg, ver, strlen(ver) )) {
 				/* Could not copy for some reason */


### PR DESCRIPTION
Previous commit with TX frame removal code causes issue with certain MaxTime database configurations and FIO module combinations. Revert and restore only the input transitions related part of that commit. 