### PR TITLE
Support for NEMA DRBIU input transitions

### DIFF
--- a/fio/src/fiodriver/fioframe.c
+++ b/fio/src/fiodriver/fioframe.c
@@ -3247,31 +3247,68 @@ This function is called when a frame 148/151 is RX'ed.
 */
 /*****************************************************************************/
 
-void
-fioman_rx_frame_148_151
-(
-	FIOMSG_RX_FRAME		*p_rx_frame		/* Frame received */
-)
-{
-	FIOMAN_SYS_FIOD		*p_sys_fiod;	/* For access to System info */
-	int i;
-	unsigned long flags;
+void fioman_rx_frame_148_151(FIOMSG_RX_FRAME *p_rx_frame /* Frame received */
+) {
+  FIOMAN_SYS_FIOD *p_sys_fiod; /* For access to System info */
+  FIOMAN_APP_FIOD *p_app_fiod; /* Ptr to app fiod structure */
+  FIO_TRANS_BUFFER entry;
+  struct list_head *p_app_elem; /* Ptr to app element being examined */
+  int i;
+  unsigned long flags;
+  uint8_t inputs[2] = {0}, trans[2] = {0};
 
-	/* Get access to system info */
-	p_sys_fiod = (FIOMAN_SYS_FIOD *)p_rx_frame->fioman_context;
+  /* Get access to system info */
+  p_sys_fiod = (FIOMAN_SYS_FIOD *)p_rx_frame->fioman_context;
 
-
-	/* Save data into FIOD System buffers */
-	spin_lock_irqsave(&p_sys_fiod->lock, flags);
-	for(i=0;i<2;i++) {
-		p_sys_fiod->inputs_raw[i] = FIOMSG_PAYLOAD(p_rx_frame)->frame_info[i+32];
-	}
-	spin_unlock_irqrestore(&p_sys_fiod->lock, flags);
-	/* TEG DEL */
-		/*pr_debug("UPDATING Frame 148/151: %x %x\n",
-			p_sys_fiod->inputs_raw[0], p_sys_fiod->inputs_raw[1] );*/
-	/* TEG DEL */
-
+  /* Save data into FIOD System buffers */
+  spin_lock_irqsave(&p_sys_fiod->lock, flags);
+  for (i = 0; i < 2; i++) {
+    inputs[i] = p_sys_fiod->inputs_raw[i] =
+        FIOMSG_PAYLOAD(p_rx_frame)->frame_info[i + 32];
+    trans[i] = FIOMSG_PAYLOAD(p_rx_frame)->frame_info[i + 34];
+  }
+  // Add transitions based on timestamps
+  for (i = 0; i < 16; i++) {
+    if (trans[i / 8] & (1 << (i % 8))) {
+      /* Update each app transition fifo */
+      entry.input_point = i;
+      entry.state = (inputs[i / 8] & (1 << (i % 8))) ? 1 : 0;
+      entry.timestamp = FIOMSG_PAYLOAD(p_rx_frame)->frame_info[i * 2];
+      entry.timestamp |= FIOMSG_PAYLOAD(p_rx_frame)->frame_info[(i * 2) + 1]
+                         << 8;
+      // push entry to each app_fiod fifo
+      list_for_each(p_app_elem, &p_sys_fiod->app_fiod_list) {
+        /* Get a ptr to this list entry */
+        p_app_fiod = list_entry(p_app_elem, FIOMAN_APP_FIOD, sys_elem);
+        if ((p_app_fiod->transition_status != FIO_TRANS_APP_OVERRUN) &&
+            ((entry.input_point == 0x7f) /* rollover entry */
+             || FIO_BIT_TEST(p_app_fiod->input_transition_map,
+                             entry.input_point))) {
+          if (FIOMAN_FIFO_AVAIL(p_app_fiod->transition_fifo) <
+              sizeof(FIO_TRANS_BUFFER)) {
+            // app fifo status is overflow
+            if (p_app_fiod->transition_status == FIO_TRANS_SUCCESS)
+              p_app_fiod->transition_status = FIO_TRANS_APP_OVERRUN;
+          } else {
+            FIOMAN_FIFO_PUT(p_app_fiod->transition_fifo, &entry,
+                            sizeof(FIO_TRANS_BUFFER));
+            pr_debug("fioman_rx_frame_148/151:transition:ip=%d state=%d "
+                     "time=%d:fifo@%p=%d, st=%d\n",
+                     entry.input_point, entry.state, entry.timestamp,
+                     &p_app_fiod->transition_fifo,
+                     kfifo_len(&p_app_fiod->transition_fifo),
+                     p_app_fiod->transition_status);
+          }
+        }
+      }
+      p_sys_fiod->input_transition_block++;
+    }
+  }
+  spin_unlock_irqrestore(&p_sys_fiod->lock, flags);
+  /* TEG DEL */
+  /*pr_debug("UPDATING Frame 148/151: %x %x\n",
+          p_sys_fiod->inputs_raw[0], p_sys_fiod->inputs_raw[1] );*/
+  /* TEG DEL */
 }
 
 /*****************************************************************************/

--- a/fio/src/fiodriver/fioman.c
+++ b/fio/src/fiodriver/fioman.c
@@ -626,10 +626,11 @@ fioman_add_frame
           /* Add to TX queue */
           txframe->cur_freq = p_sys_fiod->frame_frequency_table[frame_no];
           fiomsg_tx_add_frame(FIOMSG_P_PORT(p_sys_fiod->fiod.port), txframe);
-          if (rxframe != NULL)
+          if (rxframe != NULL) {
             /* Add to RX queue */
             fiomsg_rx_add_frame(FIOMSG_P_PORT(p_sys_fiod->fiod.port), rxframe);
-            return 0;
+          }
+          return 0;
         }
         
         return PTR_ERR(rxframe);
@@ -3615,7 +3616,6 @@ int fioman_ts2_port1_state
 	FIO_IOC_TS2_PORT1_STATE	*p_arg
 )
 {
-	FIOMAN_PRIV_DATA	*p_priv = filp->private_data;	/* Access Apps data */
         FIO_PORT                port = p_arg->port;
         FIOMSG_PORT             *p_port;
         int status;
@@ -3984,13 +3984,16 @@ int fioman_inputs_trans_set
     input_trans_map[0], input_trans_map[1], input_trans_map[2], input_trans_map[3],
     input_trans_map[4], input_trans_map[5], input_trans_map[6], input_trans_map[7]);*/
 
-  /* If any sys_fiod input config values have changed, we must schedule frame #51 */
-  p_sys_fiod->inputs_configured = false;
-  /* Ready frame 51 for this device */
-  if (!fioman_frame_is_scheduled(p_sys_fiod, FIOMAN_FRAME_NO_51)) {
-    p_sys_fiod->frame_frequency_table[FIOMAN_FRAME_NO_51] = FIO_HZ_10;
-    return fioman_add_frame(FIOMAN_FRAME_NO_51, p_sys_fiod);
-  }
+        /* If any sys_fiod input config values have changed, we must schedule frame #51 */
+        /* Does this fiod support frame 51? */
+        if (p_sys_fiod->frame_frequency_table[FIOMAN_FRAME_NO_51] != -1) {
+                p_sys_fiod->inputs_configured = false;
+                /* Ready frame 51 for this device */
+                if (!fioman_frame_is_scheduled(p_sys_fiod, FIOMAN_FRAME_NO_51)) {
+                        p_sys_fiod->frame_frequency_table[FIOMAN_FRAME_NO_51] = FIO_HZ_10;
+                        return fioman_add_frame(FIOMAN_FRAME_NO_51, p_sys_fiod);
+                }
+        }
 
   return 0;
 }
@@ -4062,7 +4065,7 @@ int fioman_inputs_trans_read
 
 	p_sys_fiod = p_app_fiod->p_sys_fiod;
 
-	/* TBD: return app-specific transition buffer entries */
+	/* return app-specific transition buffer entries */
 	spin_lock_irqsave(&p_sys_fiod->lock, flags);
 	count = FIOMAN_FIFO_LEN(p_app_fiod->transition_fifo)/sizeof(FIO_TRANS_BUFFER);
         status = p_app_fiod->transition_status;


### PR DESCRIPTION
Using input timestamp fields from frames 148-152 from detector BIUs create input transitions for the FIOAPI 