### PR TITLE
Nextfio gpiod update

### DIFF
--- a/fio/src/fiodriver/fiodrvr.c
+++ b/fio/src/fiodriver/fiodrvr.c
@@ -33,7 +33,7 @@
 dev_t fio_dev; /* Major / Minor */
 struct cdev fio_cdev; /* character device */
 
-int faultmon_gpio = -1;
+struct gpio_desc *faultmon_gpiod = NULL;
 
 
 static long fio_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
@@ -71,27 +71,20 @@ static const struct file_operations fio_fops = {
 
 static int fio_probe(struct platform_device *pdev)
 {
-	struct device_node *np = pdev->dev.of_node;
-	int gpio;
+	struct device *dev = &pdev->dev;
+	struct gpio_desc *gpiod;
 
-	gpio = of_get_gpio(np, 0); // NEMA controller type GPIO
-	if (gpio_is_valid(gpio)
-		&& (gpio_request_one(gpio, GPIOF_DIR_IN, "fiodriver") == 0)
-		&& !gpio_get_value(gpio)) {
+	gpiod = devm_gpiod_get(dev, "fiodriver", GPIOD_IN);
+	if (!IS_ERR(gpiod) && !gpiod_get_value(gpiod)) {
 		// NEMA controller type is TS2-1
-		faultmon_gpio = of_get_gpio(np, 1);
-		if (!gpio_is_valid(faultmon_gpio)) {
-			faultmon_gpio = -1;
-			dev_err(&pdev->dev, "faultmon gpio not valid\n");
-		} else if (gpio_request(faultmon_gpio, "fiodriver") != 0) {
-			faultmon_gpio = -1;
-			dev_err(&pdev->dev, "faultmon gpio request failed\n");
+		faultmon_gpiod = devm_gpiod_get(dev, "faultmon", GPIOD_OUT_LOW);
+		if (IS_ERR(faultmon_gpiod)) {
+			dev_err(dev, "faultmon gpio request failed\n");
 		} else {
-			gpio_direction_output(faultmon_gpio, 0); /* initially OFF */
-			if (gpio_cansleep(faultmon_gpio))
-				gpio_set_value_cansleep(faultmon_gpio, 0);
+			if (gpiod_cansleep(faultmon_gpiod))
+				gpiod_set_value_cansleep(faultmon_gpiod, 0);
 			else
-				gpio_set_value(faultmon_gpio, 0);
+				gpiod_set_value(faultmon_gpiod, 0);
 			dev_info(&pdev->dev, "faultmon gpio enabled\n");
 		}
 	}
@@ -105,8 +98,6 @@ static int fio_probe(struct platform_device *pdev)
 
 static int fio_remove(struct platform_device *pdev)
 {
-
-	gpio_free(faultmon_gpio);
 
 	dev_set_drvdata(&pdev->dev, NULL);
 

--- a/fio/src/fiodriver/fiodrvr.c
+++ b/fio/src/fiodriver/fiodrvr.c
@@ -56,7 +56,11 @@ static int fio_release(struct inode *inode, struct file *filp)
  */
 static struct class *fio_class;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+static char *fio_devnode(const struct device *dev, umode_t *mode)
+#else
 static char *fio_devnode(struct device *dev, umode_t *mode)
+#endif
 {
 	return kasprintf(GFP_KERNEL, "%s", dev_name(dev));
 }
@@ -147,7 +151,11 @@ static int __init fio_init(void)
 	}
 
 	/* Create a class for this device and add the device */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	fio_class = class_create("fio");
+#else
 	fio_class = class_create(THIS_MODULE, "fio");
+#endif
 	if (IS_ERR(fio_class)) {
 		printk(KERN_ERR "Error creating fio class.\n");
 		cdev_del(&fio_cdev);

--- a/fio/src/fiodriver/fioman.c
+++ b/fio/src/fiodriver/fioman.c
@@ -53,7 +53,7 @@ TEG - NO LOCKING IS IN PLACE.  THIS IS NOT AN ISSUE FOR INITIAL DEVELOPMENT
 /*#include	"fiomsg.c"*/		/* FIOMSG Code */
 /*#include	"fioframe.c"*/
 #include <linux/gpio.h>
-extern int faultmon_gpio;
+extern struct gpio_desc *faultmon_gpiod;
 
 /*  Definition section.
 -----------------------------------------------------------------------------*/
@@ -1163,11 +1163,10 @@ fioman_add_def_fiod_frames
 		case FIOOUT14SIU1:case FIOOUT14SIU2:
 		case FIO332:case FIOTS1:case FIOTS2:
 		{
-                        if (faultmon_gpio != -1) {
-                                if (p_fiod->fiod.fiod == FIOTS2) {
-                                        
-                                        break;
-                                }
+            if (!IS_ERR_OR_NULL(faultmon_gpiod)) {
+                if (p_fiod->fiod.fiod == FIOTS2) {
+                    break;
+                }
 			}
 
 			/* Ready frame 49 for this device */
@@ -2700,11 +2699,11 @@ fioman_ts_fault_monitor_set
 		return (-EINVAL);
 
 pr_debug("fioman_ts_fault_monitor_set: %d\n", p_sys_fiod->fm_state);
-        if (faultmon_gpio != -1) {
-                if (gpio_cansleep(faultmon_gpio))
-                        gpio_set_value_cansleep(faultmon_gpio, p_sys_fiod->fm_state?1:0);
+        if (!IS_ERR_OR_NULL(faultmon_gpiod)) {
+                if (gpiod_cansleep(faultmon_gpiod))
+                        gpiod_set_value_cansleep(faultmon_gpiod, p_sys_fiod->fm_state?1:0);
                 else
-                        gpio_set_value(faultmon_gpio, p_sys_fiod->fm_state?1:0);
+                        gpiod_set_value(faultmon_gpiod, p_sys_fiod->fm_state?1:0);
         }
                 
 	return 0;

--- a/fio/src/fiodriver/fiomsg.h
+++ b/fio/src/fiodriver/fiomsg.h
@@ -68,7 +68,7 @@ FIO Message Scheduler (FIOMSG).
 /* Timer definitions */
 #if defined(CONFIG_HIGH_RES_TIMERS)
 #include	<linux/hrtimer.h>
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,13,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,11,0)
 static inline ktime_t ktime_add_ms(const ktime_t kt, const u64 msec)
 {
 	return ktime_add_ns(kt, msec * NSEC_PER_MSEC);

--- a/fpu/FrontPanelSystem/FrontPanelDriver/front_panel.c
+++ b/fpu/FrontPanelSystem/FrontPanelDriver/front_panel.c
@@ -272,7 +272,11 @@ static int __init fp_init(void)
 	printk( KERN_ALERT "\n\nfront_panel loaded at major = %d\n", fp_major );
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,31)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	fp_class = class_create("front-panel");
+#else
 	fp_class = class_create(THIS_MODULE, "front-panel");
+#endif
 	if (IS_ERR(fp_class)) {
 		printk(KERN_ERR "Error creating front-panel class.\n");
 	}


### PR DESCRIPTION
Prior gpio using global integers has been deprecated, and replaced by a descriptor-based model for some years now in Linux kernel mainline. Update to maintain compatibility with kernel updates. 